### PR TITLE
Summary Page is Updating Properly

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -375,7 +375,19 @@ export default function HomeScreen() {
     if (!currentStatus) {
       setCurrentItemForCost(item);
       setCostModalVisible(true);
-    } else {
+      try {
+        const itemRef = doc(db, "households", selectedHouseholdID, "shoppingLists", shoppingListMeta.id, "items", itemId);
+        await updateDoc(itemRef, {
+          isPurchased: true,
+          purchasedDate: new Date(), // Add or clear purchasedDate
+        });  
+      } 
+      catch (error) {
+        Alert.alert('Error', 'Failed to update purchasedDate of newly purchased Item.');
+        console.error(error);
+      }
+    } 
+    else {
       try {
         const itemRef = doc(db, "households", selectedHouseholdID, "shoppingLists", shoppingListMeta.id, "items", itemId);
         await updateDoc(itemRef, {

--- a/src/screens/SummaryScreen.js
+++ b/src/screens/SummaryScreen.js
@@ -24,7 +24,7 @@ export default function SummaryPage() {
     '#91d1c8', // light blue
     '#098372',
     '#9b91d1', // light purple
-    '#91d197', // light green
+    '#9eea7d', // light green
     '#d59df9', //
     '#577d5b', // dark green
     '#418279', // dark teal


### PR DESCRIPTION
The summary page was not properly updating after adding an item and checking it off with a price because of a bug togglePurchased within HomeScreen.js, togglePurchased was originally setting purchasedDate to a new Date when a checked off item would be unchecked, which was improperly updating our Firebase Database. Summary page filters on purhcasedDate to not be null so that it can display purchased items by date, and since purchasedDate was not getting updated to a new Date() when an item was checked off the item would never be inserted.
Now with a change in togglePurchased, an item will have 'isPurchased' set to true when it's checked off and 'purchasedDate' to  new Date(), and when an item is unchecked off 'isPurchased' will become false and 'purchasedDate' will become null, so it will automatically be removed from the summary page and can be later inserted with whatever new cost the user ends up assigning that item to.

- [ ] Adding an item in a household and checking it off should properly update the Summary page
- [ ] Unchecking off a checked item should remove that data point from the Summary page
- [ ] Color of green pie slice is now a darker green

Closes #152 